### PR TITLE
Improved singleton behavior when using multiple injectable attributes

### DIFF
--- a/Ninject.Extensions.AutoBinding/app.config
+++ b/Ninject.Extensions.AutoBinding/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Ninject" publicKeyToken="c7192dc5380945e7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.4.0" newVersion="3.3.4.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Ninject.Extensions.AutoBindingTests/Mocks/BindableImplementationB.cs
+++ b/Ninject.Extensions.AutoBindingTests/Mocks/BindableImplementationB.cs
@@ -9,7 +9,8 @@ namespace Ninject.Extensions.AutoBindingTests.Mocks
 {
 
     [Injectable(Interface = typeof(IBindableService), Profiles = new string[]{ Profiles.PROFILE_B }, Scope = InjectionScope.Singleton)]
-    public class BindableImplementationB : IBindableService
+    [Injectable(Interface = typeof(IBindableServiceB), Profiles = new string[] { Profiles.PROFILE_B }, Scope = InjectionScope.Singleton)]
+    public class BindableImplementationB : IBindableService, IBindableServiceB
     {
         public string Value { get; } = Guid.NewGuid().ToString();
     }

--- a/Ninject.Extensions.AutoBindingTests/Mocks/IBindableService.cs
+++ b/Ninject.Extensions.AutoBindingTests/Mocks/IBindableService.cs
@@ -10,4 +10,9 @@ namespace Ninject.Extensions.AutoBindingTests.Mocks
     {
         string Value { get;}
     }
+
+    public interface IBindableServiceB
+    {
+      string Value { get; }
+    }
 }

--- a/Ninject.Extensions.AutoBindingTests/NinjectExtensionsAutobindingTests.cs
+++ b/Ninject.Extensions.AutoBindingTests/NinjectExtensionsAutobindingTests.cs
@@ -72,8 +72,12 @@ namespace Ninject.Extensions.AutoBinding.Tests
 
             IBindableService instance1 = container.Get<IBindableService>();
             IBindableService instance2 = container.Get<IBindableService>();
+            BindableImplementationB instance3 = container.Get<BindableImplementationB>();
+            IBindableServiceB instance4 = container.Get<IBindableServiceB>();
 
             Assert.AreSame(instance1, instance2);
+            Assert.AreSame(instance1, instance3);
+            Assert.AreSame(instance1, instance4);
         }
 
         [TestMethod]


### PR DESCRIPTION
interfaces bind to method returning target type, better singleton behavior even when multiple injectable attributes are used, see BindableImplementationB in tests